### PR TITLE
Handling of groups with cyclic references

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -243,18 +243,20 @@ function getGroupMembershipForDN(opts, dn, stack, callback) {
     var groups = [];
 
     async.forEach(results, function(group, asyncCallback) {
+      // accumulates discovered groups
       if (typeof(stack) !== 'undefined') {
-				_.each(stack,function(s) {
+				if (!_.findWhere(stack, { cn: group.cn })) {
+					stack.push(new Group({ dn: group.dn, cn: group.cn }));
+				} else {
+          // ignore groups already found
+					return asyncCallback();
+				}
+        
+        _.each(stack,function(s) {
 					if (!_.findWhere(groups, { cn: s.cn })) {
 						groups.push(s);
 					}
 				});
-				
-				if (!_.findWhere(stack, { cn: group.cn })) {
-					stack.push(new Group({ dn: group.dn, cn: group.cn }));
-				} else {
-					return asyncCallback();
-				}
 			}
 			
       groups.push(new Group({ dn: group.dn, cn: group.cn }));


### PR DESCRIPTION
This addresses the hanging problem when you have security groups in the AD that happen to have cyclic references to each other. For example, you might have a group that is member of itself. For such cases, the getGroupMembershipForDN function would hang in a recursive loop.

The proposed solution, accumulates the nested groups as they are recursively uncovered and ignores already mapped groups.
