### PR TITLE
Bug on findUser with 3 valid arguments.

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -804,7 +804,7 @@ ActiveDirectory.prototype.findUser = function() {
 
   if (typeof args[0] === "string" && argl === 2) {
     username = args[0];
-  } if (typeof args[0] === "object" && typeof args[1] === "string") { 
+  } else if (typeof args[0] === "object" && typeof args[1] === "string") { 
     if (argl === 3) { 
       opts = args[0];
       username = args[1];


### PR DESCRIPTION
@gheeres When I execute the method findUser using the opts argument your package are building the wrong filter query.

Here is my code:

``` nodejs
var opts = {attributes: [ 
    'userPrincipalName', 'sAMAccountName', /*'objectSID',*/ 'mail',
    'lockoutTime', 'whenCreated', 'pwdLastSet', 'userAccountControl',
    'employeeID', 'sn', 'givenName', 'initials', 'cn', 'displayName',
    'comment', 'description', 'extesionName'
  ]};
activeDirectory.findUser(opts, 'u100613', function(err, user) {
    console.log(user);
});
```

Here is the filter which is being executed under the hood:
`filter: '(&(objectCategory=User)(|(sAMAccountName=[object Object])(userPrincipalName=[object Object])))',`

On your method `ActiveDirectory.prototype.findUser` you're making a condition which I think it is the source of the problem:

```
if (typeof(includeMembership) === 'function') {
    callback = includeMembership;
    includeMembership = username;
    username = opts;
  }
```

In my scenario... includeMembership is a function... If you put a console.log right after the method signature to check those argument types.
`console.log(typeof opts, typeof username, typeof includeMembership, typeof callback)``
The output would be:
``object string function undefined``

So... on that scenario... that `if` is assigning `opts` as my username and the filter query are getting the wrong output as you can see.

What I did was change your method signature to rely on `arguments` and I also improve a little bit the logic of those assignments. 
