### PR TITLE
authenticate: empty user/password bugfix

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -855,7 +855,7 @@ ActiveDirectory.prototype.authenticate = function authenticate(username, passwor
         'description': 'The supplied credential is invalid'
       };
       callback(err, false);
-    }err
+    }
     return;
   }
 


### PR DESCRIPTION
When pass an empty user/password the callback must be passed with an error. But it's not defined.

Creating an error object based on http://technet.microsoft.com/en-us/library/bb463166.aspx
