### PR TITLE
Added findUsers to API to find all matching users

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -946,6 +946,45 @@ ActiveDirectory.prototype.findUser = function findUser(opts, username, includeMe
 };
 
 /**
+ * Retrieves the specified users based on the filter provided.
+ *
+ * @public
+ * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0 }
+ * @param {Function} callback The callback to execute when completed. callback(err: {Object}, user: {User})
+ */
+ActiveDirectory.prototype.findUsers = function findUsers(opts, callback) {
+  var self = this
+      users = []
+  ;
+
+  var opts = _.defaults(opts || {}, {
+    filter: '(samaccountname=*)',
+    scope: 'sub',
+    attributes: defaultAttributes.user
+  });
+  search.call(self, opts, function onSearch(err, results) {
+    var i=0;
+
+    if (err) {
+      if (callback) callback(err);
+      return;
+    }
+
+    if ((! results) || (results.length == 0)) {
+      if (callback) callback();
+      return;
+    }
+
+    for(i=0; i<results.length; i++) {
+      users.push(new User(results[i]));
+    }
+
+    self.emit('users', users);
+    if (callback) callback(err, users);
+  });
+};
+
+/**
  * Attempts to authenticate the specified username / password combination.
  *
  * @public


### PR DESCRIPTION
I have added a version of findUser that would allow me to get a list of users based on a filter I pass in. I excluded includeMembership due to potential performance cost.
