### PR TITLE
return object sid/guid as buffer instead of string

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -276,6 +276,19 @@ function search(baseDN, opts, callback) {
      */
     function onSearchEntry(entry) {
       var result = entry.object;
+      
+      //If there is object sid return the raw object - means the buffer it self
+      // Because convert from the string back to the buffer is problem
+      if (entry.raw.hasOwnProperty("objectSid")){
+        result.objectSid = entry.raw.objectSid;
+      }
+      
+      //If there is object guid return the raw object - means the buffer it self
+      // Because convert from the string back to the buffer is problem
+      if (entry.raw.hasOwnProperty("objectGUID")){
+        result.objectGUID = entry.raw.objectGUID;
+      }
+      
       delete result.controls; // Remove the controls array returned as part of the SearchEntry
 
       // Some attributes can have range attributes (paging). Execute the query


### PR DESCRIPTION
when querying object sid or object guid return the buffer it self instead of string representation because when convert back to buffer for querying by buffer later is not success otherwise.
