### PR TITLE
pass tlsOptions to ldapjs if supplied

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -47,15 +47,14 @@ var defaultReferrals = {
  */
 var ActiveDirectory = function(url, baseDN, username, password, defaults) {
   if (typeof(url) === 'object') {
-    var opts = url;
-    this.url = opts.url;
-    this.baseDN = opts.baseDN;
-    this.username = opts.username;
-    this.password = opts.password;
-    this.tlsOptions = opts.tlsOptions;
+    this.opts = url;
+    this.url = this.opts.url;
+    this.baseDN = this.opts.baseDN;
+    this.username = this.opts.username;
+    this.password = this.opts.password;
 
-    defaultAttributes = _.extend({}, defaultAttributes, opts.attributes || {});
-    defaultReferrals = _.extend({}, defaultReferrals, opts.referrals || {});
+    defaultAttributes = _.extend({}, defaultAttributes, this.opts.attributes || {});
+    defaultReferrals = _.extend({}, defaultReferrals, this.opts.referrals || {});
   }
   else {
     this.url = url;
@@ -202,12 +201,7 @@ function createClient(url) {
     throw 'No url specified for ActiveDirectory client.';
   }
 
-  var opts = { url: url };
-  if (this.tlsOptions) {
-    opts.tlsOptions = this.tlsOptions;
-  }
-
-  var client = ldap.createClient(opts);
+  var client = ldap.createClient(this.opts);
   return(client);
 }
 


### PR DESCRIPTION
Right now there's no way to pass any TLS options to ldapjs. This PR fixes that.
