### PR TITLE
Update activedirectory.js

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -114,6 +114,12 @@ var ActiveDirectory = function(url, baseDN, username, password, defaults) {
 util.inherits(ActiveDirectory, events.EventEmitter);
 
 /**
+ * Expose ldapjs filters to avoid TypeErrors for filters
+ * @static
+ */
+ActiveDirectory.filters = ldap.filters;
+
+/**
  * Truncates the specified output to the specified length if exceeded.
  * @param {String} output The output to truncate if too long
  * @param {Number} [maxLength] The maximum length. If not specified, then the global value maxOutputLength is used.


### PR DESCRIPTION
Expose the ldapjs filters so that the documented find filter will actually be able to accept a Filter.   Also, when the new (0.7.2 / 0.8.0) ldapjs version is out, this will allow for binary filters to work.