### PR TITLE
Fixed event listener check binding

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -1644,7 +1644,7 @@ ActiveDirectory.prototype.authenticate = function authenticate(username, passwor
     // Ignore ECONNRESET errors
     if ((err || {}).errno !== 'ECONNRESET') {
       log.error('An unhandled error occured on bind at "%s". Error: %j', self.opts.url, err);
-      if (hasEvents('error')) self.emit('error', err);
+      if (hasEvents.call(self, 'error')) self.emit('error', err);
     }
   });
   client.bind(username, password, function(err, result) {
@@ -1693,7 +1693,7 @@ ActiveDirectory.prototype.getRootDSE = function getRootDSE(url, attributes, call
     // Ignore ECONNRESET errors
     if ((err || {}).errno !== 'ECONNRESET') {
       log.error('An unhandled error occured when searching for the root DSE at "%s". Error: %j', url, err);
-      if (hasEvents('error')) self.emit('error', err)
+      if (hasEvents.call('self, 'error')) self.emit('error', err)
     }
   }
 


### PR DESCRIPTION
When calling 'hasEvents' from a callback, "this" was not bound to the AD instance, and was defaulting to global scope.  Changing them to '.call's fixes this.