### PR TITLE
remove 2 global variables

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -22,7 +22,8 @@ var log = bunyan.createLogger({
 });
 
 var defaultPageSize = 1000; // The maximum number of results that AD will return in a single call. Default=1000
-var defaultAttributes = originalDefaultAttributes = {
+var defaultAttributes, originalDefaultAttributes;
+defaultAttributes = originalDefaultAttributes = {
   user: [ 
     'dn',
     'userPrincipalName', 'sAMAccountName', /*'objectSID',*/ 'mail',
@@ -35,7 +36,8 @@ var defaultAttributes = originalDefaultAttributes = {
   ]
 };
 
-var defaultReferrals = originalDefaultReferrals = {
+var defaultReferrals, originalDefaultReferrals;
+defaultReferrals = originalDefaultReferrals = {
   enabled: false,
   // Active directory returns the following partitions as default referrals which we don't want to follow
   exclude: [


### PR DESCRIPTION
originalDefaultReferrals & originalDefaultAttributes are not declared in the current scope, so they are declared in the global scope...

```js
require('activedirectory');
console.log(typeof originalDefaultAttributes); // print 'object'
```