### PR TITLE
getGroupMembershipForUser returning zero groups for cn's containing quotes

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -175,8 +175,7 @@ function parseDistinguishedName(dn) {
   log.trace('parseDistinguishedName(%s)', dn);
   if (! dn) return(dn);
 
-  // Currently a bug in ldapjs that isn't properly escaping DNs with ','
-  // in the name.
+  dn = dn.replace(/"/g, '\\"');
   return(dn.replace('\\,', '\\\\,'));
 }
 


### PR DESCRIPTION
parseDistinguishedName updated to escape quotes in DN