### PR TITLE
#122 Broken paging

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "url": "https://github.com/gheeres/node-activedirectory/issues"
   },
   "dependencies": {
-    "async": ">= 0.1.22",
-    "bunyan": ">= 1.3.5",
-    "ldapjs": ">= 0.7.1",
-    "underscore": ">= 1.4.3"
+    "async": "^1.5.x",
+    "bunyan": "^1.5.x",
+    "ldapjs": "^0.7.x",
+    "underscore": "^1.8.x"
   },
   "repository": {
     "type": "git",
@@ -29,6 +29,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.x"
   }
 }


### PR DESCRIPTION
Fix the compatible version of dependencies to revert ldapjs to version 0.7.x. This resolves #122.

Versions of other dependencies have also been fixed to the current latest major version releases (the versions which would have been installed with the existing dependencies specification. These versions are assumed to work correctly, however this has not been explicitly tested.
