### PR TITLE
Correct error: unknown stream type "undefined" in bunyan

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -15,10 +15,8 @@ var maxOutputLength = 256;
 
 var log = bunyan.createLogger({
   name: 'ActiveDirectory',
-  streams: [
-    { level: 'fatal',
-      stream: process.stdout }
-  ]
+  level: 'fatal',
+  stream: process.stdout
 });
 
 var defaultPageSize = 1000; // The maximum number of results that AD will return in a single call. Default=1000


### PR DESCRIPTION
I was getting this error :

Uncaught TypeError: unknown stream type "undefined"
    at Logger.addStream (webpack:///./~/bunyan/lib/bunyan.js?:620:15)
    at eval (webpack:///./~/bunyan/lib/bunyan.js?:470:18)
    at Array.forEach (native)
    at new Logger (webpack:///./~/bunyan/lib/bunyan.js?:469:25)
    at Function.createLogger (webpack:///./~/bunyan/lib/bunyan.js?:1618:12)
    at Object.eval (webpack:///./~/activedirectory/lib/activedirectory.js?:16:18)
    at eval (webpack:///./~/activedirectory/lib/activedirectory.js?:1901:30)

I corrected it removing the streams element.
Now it works.