### PR TITLE
Force objectClass

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -735,7 +735,7 @@ function getGroupMembershipForDN(opts, dn, stack, callback) {
   opts = _.defaults(_.omit(opts || {}, 'filter', 'scope', 'attributes'), {
     filter: '(member='+parseDistinguishedName(dn)+')',
     scope: 'sub',
-    attributes: joinAttributes((opts || {}).attributes || defaultAttributes.group, [ 'groupType' ])
+    attributes: joinAttributes((opts || {}).attributes || defaultAttributes.group, [ 'groupType', 'objectClass' ])
   });
   search.call(self, opts, function(err, results) {
     if (err) {


### PR DESCRIPTION
OpenLDAP by default doesn't return objectClass.  Request this specifically.