### PR TITLE
Escape parentheses when doing a nested group request

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -175,7 +175,7 @@ function parseDistinguishedName(dn) {
   log.trace('parseDistinguishedName(%s)', dn);
   if (! dn) return(dn);
 
-  dn = dn.replace(/"/g, '\\"');
+  dn = dn.replace(/"/g, '\\"').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
   return(dn.replace('\\,', '\\\\,'));
 }
 


### PR DESCRIPTION
Hi,
I encountered a bug when using node-activedirectory's `getGroupMembershipForUser` method.

One of my users is member of the group `CN=All Management(EM+Directors),OU=Distribution Groups,DC=...,DC=...` which contains parentheses in the name.

This PR automatically escapes parenthesis in nested filters.

I tried to make a test but couldn't have them run locally, is there a documentation on how to run them ? a docker image maybe ?

I tested this change in my application and it seemed to work correctly.
