### PR TITLE
Allow to disable nested groups extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ Currently supported ldapjs opts are:
 * attributes - attributes to select and return (if these are set, the server will return only these attributes). Defaults to the empty set, which means all attributes.
 * sizeLimit - the maximum number of entries to return. Defaults to 0 (unlimited).
 * timeLimit - the maximum amount of time the server should take in responding, in seconds. Defaults to 10. Lots of servers will ignore this.
+* includeNestedGroups - You can optionally pass here False if the results shouldn't include nested groups. Default is True.
 
 Options for activedirectory.js:
 

--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -1601,7 +1601,7 @@ ActiveDirectory.prototype.findGroups = function findGroup(opts, callback) {
     // Parse the results in parallel.
     async.forEach(results, function(result, asyncCallback) {
       if (isGroupResult(result)) {
-        var group = new Group(pickAttributes(result, (opts || {}).attributes || defaultAttributes.user));
+        var group = new Group(pickAttributes(result, (opts || {}).attributes || defaultAttributes.group));
         groups.push(group);
 
         // Also retrieving user group memberships?

--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -697,7 +697,7 @@ function pickAttributes(result, attributes) {
  * Gets all of the groups that the specified distinguishedName (DN) belongs to.
  * 
  * @private
- * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0 }
+ * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0, includeNestedGroups: {Boolean} }
  * @param {String} dn The distinguishedName (DN) to find membership of.
  * @param {Function} callback The callback to execute when completed. callback(err: {Object}, groups: {Array[Group]})
  */
@@ -765,6 +765,9 @@ function getGroupMembershipForDN(opts, dn, stack, callback) {
         log.debug('Adding group "%s" to %s"', group.dn, dn);
         groups.push(new Group(group));
 
+        if (!opts.includeNestedGroups) {
+          asyncCallback();
+        } else {
         // Get the groups that this group may be a member of.
         log.debug('Retrieving nested group membership for group "%s"', group.dn);
         getGroupMembershipForDN.call(self, opts, group.dn, groups, function(err, nestedGroups) {
@@ -785,6 +788,7 @@ function getGroupMembershipForDN(opts, dn, stack, callback) {
           Array.prototype.push.apply(groups, nestedGroups);
           asyncCallback();
         });
+        }
       }
       else asyncCallback();
     }, function(err) {
@@ -1085,7 +1089,7 @@ ActiveDirectory.prototype.getUsersForGroup = function getUsersForGroup(opts, gro
  * For the specified username, get all of the groups that the user is a member of.
  *
  * @public
- * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0 }
+ * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0, includeNestedGroups: {Boolean} }
  * @param {String} username The username to retrieve membership information about.
  * @param {Function} [callback] The callback to execute when completed. callback(err: {Object}, groups: {Array[Group]})
  */
@@ -1131,7 +1135,7 @@ ActiveDirectory.prototype.getGroupMembershipForUser = function getGroupMembershi
  * For the specified group, get all of the groups that the group is a member of.
  *
  * @public
- * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0 }
+ * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0, includeNestedGroups: {Boolean} }
  * @param {String} groupName The group to retrieve membership information about.
  * @param {Function} [callback] The callback to execute when completed. callback(err: {Object}, groups: {Array[Group]})
  */
@@ -1300,7 +1304,7 @@ function includeGroupMembershipFor(opts, name) {
  * (i.e. computer accounts, etc.) can be found in the 'other' attribute / array of the result.
  *
  * @public
- * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0 }. Optionally, if only a string is provided, then the string is assumed to be an LDAP filter.
+ * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0, includeNestedGroups: {Boolean} }. Optionally, if only a string is provided, then the string is assumed to be an LDAP filter.
  * @param {Function} callback The callback to execute when completed. callback(err: {Object}, { users: [ User ], groups: [ Group ], other: [ ] )
  */
 ActiveDirectory.prototype.find = function find(opts, callback) {
@@ -1496,7 +1500,7 @@ ActiveDirectory.prototype.findDeletedObjects = function find(opts, callback) {
  * Retrieves the specified group.
  *
  * @public
- * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0 }
+ * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0, includeNestedGroups: {Boolean} }
  * @param {String} groupName The group (cn) to retrieve information about. Optionally can pass in the distinguishedName (dn) of the group to retrieve.
  * @param {Function} callback The callback to execute when completed. callback(err: {Object}, group: {Group})
  */
@@ -1559,7 +1563,7 @@ ActiveDirectory.prototype.findGroup = function findGroup(opts, groupName, callba
  * specified as (&(objectClass=group)(!(objectClass=computer))(!(objectClass=user))(!(objectClass=person)))
  *
  * @public
- * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0 }. Optionally, if only a string is provided, then the string is assumed to be an LDAP filter that will be appended as the last parameter in the default LDAP filter.
+ * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0, includeNestedGroups: {Boolean} }. Optionally, if only a string is provided, then the string is assumed to be an LDAP filter that will be appended as the last parameter in the default LDAP filter.
  * @param {Function} callback The callback to execute when completed. callback(err: {Object}, groups: [ Group ])
  */
 ActiveDirectory.prototype.findGroups = function findGroup(opts, callback) {
@@ -1637,7 +1641,7 @@ ActiveDirectory.prototype.findGroups = function findGroup(opts, callback) {
  * Retrieves the specified user.
  *
  * @public
- * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0 }
+ * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0, includeNestedGroups: {Boolean} }
  * @param {String} username The username to retrieve information about. Optionally can pass in the distinguishedName (dn) of the user to retrieve.
  * @param {Boolean} [includeMembership] OBSOLETE; NOT NOT USE. Indicates if the results should include group memberships for the user. Defaults to false.
  * @param {Function} callback The callback to execute when completed. callback(err: {Object}, user: {User})
@@ -1709,7 +1713,7 @@ ActiveDirectory.prototype.findUser = function findUser(opts, username, includeMe
  * specified as (&(|(objectClass=user)(objectClass=person))(!(objectClass=computer))(!(objectClass=group)))
  *
  * @public
- * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0 }. Optionally, if only a string is provided, then the string is assumed to be an LDAP filter that will be appended as the last parameter in the default LDAP filter.
+ * @param {Object} [opts] Optional LDAP query string parameters to execute. { scope: '', filter: '', attributes: [ '', '', ... ], sizeLimit: 0, timelimit: 0, includeNestedGroups: {Boolean} }. Optionally, if only a string is provided, then the string is assumed to be an LDAP filter that will be appended as the last parameter in the default LDAP filter.
  * @param {Boolean} [includeMembership] OBSOLETE; NOT NOT USE. Indicates if the results should include group memberships for the user. Defaults to false.
  * @param {Function} callback The callback to execute when completed. callback(err: {Object}, users: [ User ])
  */


### PR DESCRIPTION
This PR is to allow to disable nested groups extraction: [see commit](https://github.com/gheeres/node-activedirectory/pull/245/commits/afbf81482b23877d20047b187568fd9a4f3a4280)

It's also fixes a typo when wrong default attributes for groups passed: [see commit](https://github.com/gheeres/node-activedirectory/commit/fad7593163a0f229cd59ba5f1b135a5c045caa73)